### PR TITLE
Rails 7 active storage with Token and Attachment name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,6 @@ module.exports = class ActiveStorageUpload extends Plugin {
         timer.done();
 
         if (error) {
-          console.log('error')
           const response = {
             status: 'error',
           };

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
         data.name = meta.name;
       }
 
-      const upload = new DirectUpload(data, this.opts.directUploadUrl, token, '', directHandlers);
+      const upload = new DirectUpload(data, this.opts.directUploadUrl, this.opts.token, '', directHandlers);
       const id = cuid();
 
       upload.create((error, blob) => {
@@ -101,6 +101,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
         timer.done();
 
         if (error) {
+          console.log('error')
           const response = {
             status: 'error',
           };

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
     this.title = opts.title || 'ActiveStorageUpload';
     this.type = 'uploader';
     this.token = opts.token || '';
+    this.attachmentName = opts.attachmentName || ''
 
     const defaultOptions = {
       limit: 0,
@@ -93,7 +94,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
         data.name = meta.name;
       }
 
-      const upload = new DirectUpload(data, this.opts.directUploadUrl, this.opts.token, '', directHandlers);
+      const upload = new DirectUpload(data, this.opts.directUploadUrl, this.opts.token, this.opts.attachmentName, directHandlers);
       const id = cuid();
 
       upload.create((error, blob) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
     this.id = opts.id || 'ActiveStorageUpload';
     this.title = opts.title || 'ActiveStorageUpload';
     this.type = 'uploader';
+    this.token = opts.token || '';
 
     const defaultOptions = {
       limit: 0,
@@ -92,7 +93,7 @@ module.exports = class ActiveStorageUpload extends Plugin {
         data.name = meta.name;
       }
 
-      const upload = new DirectUpload(data, this.opts.directUploadUrl, directHandlers);
+      const upload = new DirectUpload(data, this.opts.directUploadUrl, token, '', directHandlers);
       const id = cuid();
 
       upload.create((error, blob) => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@uppy/companion-client": "0.27.2",
     "@uppy/utils": "0.27.1",
-    "@rails/activestorage": "^6.0.0",
+    "@rails/activestorage": "^7.0.0",
     "cuid": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello :) 

We upgraded to rails 7 and we figured out that we now need to provide `direct_upload_token` and `attachment_name` as params in order to upload file. 
This version is now using "@rails/activestorage": "^7.0.0" . 
You can now pass a token and an attachmentName as an option: 

```
uppy.use(ActiveStorageUpload, {
    directUploadUrl: directUploadUrl,
    token: directUploadToken,
    attachmentName: directUploadAttachmentName
  });
```