### PR TITLE
Remove token and attachmentName that broke directHandlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,6 @@ module.exports = class ActiveStorageUpload extends BasePlugin {
     this.id = opts.id || 'ActiveStorageUpload';
     this.title = opts.title || 'ActiveStorageUpload';
     this.type = 'uploader';
-    this.token = opts.token || '';
-    this.attachmentName = opts.attachmentName || ''
 
     const defaultOptions = {
       limit: 0,
@@ -94,7 +92,7 @@ module.exports = class ActiveStorageUpload extends BasePlugin {
         data.name = meta.name;
       }
 
-      const upload = new DirectUpload(data, this.opts.directUploadUrl, this.opts.token, this.opts.attachmentName, directHandlers);
+      const upload = new DirectUpload(data, this.opts.directUploadUrl, directHandlers);
       const id = cuid();
 
       upload.create((error, blob) => {


### PR DESCRIPTION
Hello @excid3 ! 

We recently make an upgrade to uppy 2.x and we lost the `upload-progress` listener. 

We seen it was due to these changes:
https://github.com/excid3/uppy-activestorage-upload/pull/3/commits/c3540bb72c7de4bea572f3a4d0872d394201c94b

That looks like it should be reverted: https://github.com/excid3/uppy-activestorage-upload/pull/4/files

Thank you!