### PR TITLE
Security/np

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "@rails/activestorage": "^7.0.4",
-    "@uppy/core": "^3.0.4"
+    "@uppy/core": "^3.0.4",
+    "np": "*"
   },
   "peerDependencies": {
     "@rails/activestorage": "*",
@@ -41,6 +42,5 @@
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.0.1",
-    "np": "^7.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "@excid3:registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
-    "@paralleldrive/cuid2": "^2.0.1",
+    "@paralleldrive/cuid2": "^2.0.1"
   }
 }


### PR DESCRIPTION
Hello @excid3 !

We have 2 opened vulnerabilities caused by this project:

```
Dependabot cannot update got to a non-vulnerable version
The latest possible version that can be installed is 9.6.0 because of the following conflicting dependencies:

@excid3/uppy-activestorage-upload@1.0.0 requires got@^10.6.0 via a transitive dependency on npm-name@6.0.1
@excid3/uppy-activestorage-upload@1.0.0 requires got@^9.6.0 via a transitive dependency on package-json@6.5.0
The earliest fixed version is 11.8.5.
```

```
Dependabot cannot update semver to a non-vulnerable version
The latest possible version that can be installed is 5.7.2 because of the following conflicting dependencies:

@excid3/uppy-activestorage-upload@1.0.0 requires semver@^7.3.4 via a transitive dependency on normalize-package-data@3.0.3
@excid3/uppy-activestorage-upload@1.0.0 requires semver@2 || 3 || 4 || 5 via a transitive dependency on normalize-package-data@2.5.0
@excid3/uppy-activestorage-upload@1.0.0 requires semver@^7.3.4 via a transitive dependency on np@7.7.0
@excid3/uppy-activestorage-upload@1.0.0 requires semver@^7.3.4 via a transitive dependency on update-notifier@5.1.0
mjml@4.14.1 requires semver@^7.5.3 via a transitive dependency on editorconfig@1.0.4
nodemon@3.0.1 requires semver@^7.5.3
nodemon@3.0.1 requires semver@^7.5.3 via simple-update-notifier@2.0.0
eslint@7.32.0 requires semver@^7.2.1
stylelint@15.10.2 requires semver@^7.3.4 via a transitive dependency on normalize-package-data@3.0.3
yarn-audit-fix@9.3.6 requires semver@^7.3.7
yarn-audit-fix@9.3.6 requires semver@^7.3.5 via a transitive dependency on synp@1.9.10
The earliest fixed version is 6.3.1.
```

Moving `np` package to `devDependencies` as recommended: https://github.com/sindresorhus/np#release-script
Losing version as shown in the README