### PR TITLE
upload-progress event uploader -> uploadStarted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ export default class ActiveStorageUpload extends BasePlugin {
 
         if (ev.lengthComputable) {
           this.uppy.emit("upload-progress", file, {
-            uploader: this,
+            uploadStarted: file.progress.uploadStarted ?? 0,
             bytesUploaded: ev.loaded,
             bytesTotal: ev.total,
           })


### PR DESCRIPTION
The general progress event seems to be busted and I'm not familiar enough with the Uppy codebase to know if this will fix it, however, what I can tell is that all instances where this event used to include an uploader param have been scrubbed and replaced with this param that signifies the elapsed time since the file started uploading. As far as I can tell this is happening at the beginning of each chunk of the upload but I am happy to defer if I am not understanding correctly.