### PR TITLE
Replaces require with import for better compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import { createId } from "@paralleldrive/cuid2"
 // const emitSocketProgress = require('@uppy/utils/lib/emitSocketProgress');
 // const getSocketHost = require('@uppy/utils/lib/getSocketHost');
 import "@uppy/utils/lib/RateLimitedQueue"
-const { DirectUpload } = require("@rails/activestorage")
+import { DirectUpload } from "@rails/activestorage"
 
 export default class ActiveStorageUpload extends BasePlugin {
   constructor(uppy, opts) {


### PR DESCRIPTION
This PR replaces `require` with `import` for better compatibility with Bun